### PR TITLE
Jenkins feature: reorganize initialize stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -331,6 +331,38 @@ pipeline {
                     env.CHANGE_TARGET = env.CHANGE_TARGET_HGCTPGVAL
                     println( "Validation of the validation: Set the original name of CHANGE_BRANCH => " + env.CHANGE_BRANCH )
                 }
+                
+                def message = ""
+                if (currentBuild.result == 'SUCCESS') {
+                    message = "The validation checks have passed." + "<br>" + "The comparison histograms are available [here](${env.WEBPAGES_VAL}list_config.php?pr=/PR$CHANGE_ID)"
+                } else if (currentBuild.result == 'FAILURE') {
+                    message = "Some of the validation checks have failed." + "<br>" + "More details can be found [here](${env.CHANGE_URL}/checks)"
+                
+                }
+                
+                withEnv(["MESSAGE=${message}","url=${env.CHANGE_URL}"]) {
+                    // Generate a token, the command "set +x" is mandatory
+                    sh'set +x exec >> log_Jenkins; module use /opt/exp_soft/vo.llr.in2p3.fr/modulefiles_el7/; module purge; module load python/3.9.9; python /data/jenkins/workspace/create_token_hgc-tpg.py > /tmp/github_token'
+                    sh '''
+                        # This command is mandatory
+                        set +x
+                        # Compose the url to be used for printing the message in the GitHub PR thread
+                        # In the string "url" replace "pull" with "issues" and add at the end "comments"
+                        url_comments1="${url/pull/issues}/comments"
+                        # In the string "url_comments1" replace "github.com" with "api.github.com/repos"
+                        url_comments2="${url_comments1/github.com/api.github.com/repos}"
+                        GITHUB_ACCESS_TOKEN=$(cat /tmp/github_token)
+                        if [[ -z "${GITHUB_ACCESS_TOKEN}" ]]; then
+                            echo 'The github access token has not been generated.'
+                        else
+                            curl -X POST -H "Authorization: Bearer $GITHUB_ACCESS_TOKEN " \
+                            -H "Accept: application/vnd.github+json" \
+                             -d "{\\"body\\": \\"$MESSAGE\\" }"  \
+                            $url_comments2
+                        fi
+                        rm -f /tmp/github_token
+                    '''
+                }
             }
             archiveArtifacts artifacts: 'log_Jenkins', fingerprint: true
         }
@@ -338,7 +370,7 @@ pipeline {
             echo 'The job finished successfully.'
             mail to: "${EMAIL_TO}",
                  subject: "Jenkins job succeded: ${currentBuild.fullDisplayName}",
-                 body:  "The job finished successfully. \n\n Pull request: ${env.BRANCH_NAME} build number: #${env.BUILD_NUMBER} \n\n Title: ${env.CHANGE_TITLE} \n\n Author of the PR: ${env.CHANGE_AUTHOR} \n\n Target branch: ${env.CHANGE_TARGET} \n\n Feature branch: ${env.CHANGE_BRANCH} \n\n Check console output at ${env.BUILD_URL} \n\n and ${env.CHANGE_URL} to view the results.  \n\n The validation histograms are available at ${env.WEBPAGES_VAL} \n\n"
+                 body:  "The job finished successfully. \n\n Pull request: ${env.BRANCH_NAME} build number: #${env.BUILD_NUMBER} \n\n Title: ${env.CHANGE_TITLE} \n\n Author of the PR: ${env.CHANGE_AUTHOR} \n\n Target branch: ${env.CHANGE_TARGET} \n\n Feature branch: ${env.CHANGE_BRANCH} \n\n Check console output at ${env.BUILD_URL} \n\n and ${env.CHANGE_URL} to view the results.  \n\n The validation histograms are available at ${env.WEBPAGES_VAL}list_config.php?pr=/PR$CHANGE_ID \n\n"
         }
         failure {
             echo 'Job failed'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,6 +136,10 @@ pipeline {
                         echo '==> Install automatic validation package HGCTPGValidation. ============================'
                         exec >> log_Jenkins
                         echo '==> Install automatic validation package HGCTPGValidation. ============================'
+                        if [ -d "./HGCTPGValidation" ] 
+                        then
+                            rm -rf HGCTPGValidation
+                        fi
                         git clone -b ${BRANCH_HGCTPGVAL} https://github.com/${REMOTE_HGCTPGVAL}/HGCTPGValidation HGCTPGValidation
                         source HGCTPGValidation/env_install.sh
                         pip install attrs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,10 +143,6 @@ pipeline {
                         echo '==> Install automatic validation package HGCTPGValidation. ============================'
                         exec >> log_Jenkins
                         echo '==> Install automatic validation package HGCTPGValidation. ============================'
-                        uname -a
-                        whoami
-                        pwd
-                        ls -l
                         git clone -b ${BRANCH_HGCTPGVAL} https://github.com/${REMOTE_HGCTPGVAL}/HGCTPGValidation HGCTPGValidation
                         source HGCTPGValidation/env_install.sh
                         pip install attrs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,10 +147,6 @@ pipeline {
                         whoami
                         pwd
                         ls -l
-                        if [ -d "./HGCTPGValidation" ] 
-                        then
-                            rm -rf HGCTPGValidation
-                        fi
                         git clone -b ${BRANCH_HGCTPGVAL} https://github.com/${REMOTE_HGCTPGVAL}/HGCTPGValidation HGCTPGValidation
                         source HGCTPGValidation/env_install.sh
                         pip install attrs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,11 +150,6 @@ pipeline {
                         git clone -b ${BRANCH_HGCTPGVAL} https://github.com/${REMOTE_HGCTPGVAL}/HGCTPGValidation HGCTPGValidation
                         source HGCTPGValidation/env_install.sh
                         pip install attrs
-                        if [ -d "./test_dir" ] 
-                        then
-                            echo "Directory test_dir exists."
-                            rm -rf test_dir
-                        fi
                         mkdir test_dir
                         ls -lrt ..
                         echo '   '

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,6 +129,13 @@ pipeline {
         }
         stage('Initialize'){
             stages{
+                stage('Clean the working environment'){
+                    steps{
+                        sh '''
+                        ./HGCTPGValidation/scripts/clean_environment.sh ${DATA_DIR} PR$CHANGE_ID
+                        '''
+                    }
+                }
                 stage('Install automatic validation package HGCTPGValidation') {
                     steps {
                         sh '''
@@ -155,13 +162,6 @@ pipeline {
                         mkdir test_dir
                         ls -lrt ..
                         echo '   '
-                        '''
-                    }
-                }
-                stage('Clean the working environment'){
-                    steps{
-                        sh '''
-                        ./HGCTPGValidation/scripts/clean_environment.sh ${DATA_DIR} PR$CHANGE_ID
                         '''
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,6 @@ pipeline {
                         git clone -b ${BRANCH_HGCTPGVAL} https://github.com/${REMOTE_HGCTPGVAL}/HGCTPGValidation HGCTPGValidation
                         source HGCTPGValidation/env_install.sh
                         pip install attrs
-                        mkdir test_dir
                         ls -lrt ..
                         echo '   '
                         '''
@@ -153,6 +152,7 @@ pipeline {
                     steps{
                         sh '''
                         ./HGCTPGValidation/scripts/clean_environment.sh ${DATA_DIR} PR$CHANGE_ID
+                        mkdir test_dir
                         '''
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,13 +129,6 @@ pipeline {
         }
         stage('Initialize'){
             stages{
-                stage('Clean the working environment'){
-                    steps{
-                        sh '''
-                        ./HGCTPGValidation/scripts/clean_environment.sh ${DATA_DIR} PR$CHANGE_ID
-                        '''
-                    }
-                }
                 stage('Install automatic validation package HGCTPGValidation') {
                     steps {
                         sh '''
@@ -149,6 +142,13 @@ pipeline {
                         mkdir test_dir
                         ls -lrt ..
                         echo '   '
+                        '''
+                    }
+                }
+                stage('Clean the working environment'){
+                    steps{
+                        sh '''
+                        ./HGCTPGValidation/scripts/clean_environment.sh ${DATA_DIR} PR$CHANGE_ID
                         '''
                     }
                 }

--- a/config/job_val_params.yaml
+++ b/config/job_val_params.yaml
@@ -4,4 +4,4 @@ description:
     validating the new development in the validation code
 parameters:
     cmsswRemote: hgc-tpg
-    cmsswBranch: hgc-tpg-CMSSW_12_5_2_patch1
+    cmsswBranch: hgc-tpg-devel-CMSSW_14_0_0_pre1

--- a/config/user_envvar.sh
+++ b/config/user_envvar.sh
@@ -6,10 +6,10 @@
 # Variables to modify by the user ############################
 
 # CMSSW
-export SCRAM_ARCH='slc7_amd64_gcc10'
+export SCRAM_ARCH='slc7_amd64_gcc12'
 echo $SCRAM_ARCH
 
-export REF_RELEASE='CMSSW_12_5_2_patch1'
+export REF_RELEASE='CMSSW_14_0_0_pre1'
 echo $REF_RELEASE
 
 export BASE_REMOTE='hgc-tpg'
@@ -18,10 +18,10 @@ echo $BASE_REMOTE
 export REMOTE='hgc-tpg'
 echo $REMOTE
 
-export CHANGE_BRANCH='hgc-tpg-CMSSW_12_5_2_patch1'
+export CHANGE_BRANCH='hgc-tpg-devel-CMSSW_14_0_0_pre1'
 echo $CHANGE_BRANCH
 
-export CHANGE_TARGET='hgc-tpg-CMSSW_12_5_2_patch1'
+export CHANGE_TARGET='hgc-tpg-devel-CMSSW_14_0_0_pre1'
 echo $CHANGE_TARGET
 
 CONFIG_SUBSET='default_multi_subset'

--- a/scripts/clean_environment.sh
+++ b/scripts/clean_environment.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Usage: ./HGCTPGValidation/scripts/clean_environment.sh ${DATA_DIR} PR$CHANGE_ID
+
+# Check if there are 2 arguments supplied to the script
+if (( $# != 2 ))
+then
+  echo "Usage: ./HGCTPGValidation/scripts/clean_environment.sh DATA_DIR PR_ID"
+  exit 1
+fi
+
+DATA_DIR=$1
+PRCHANGE_ID=$2
+
+set +x
+echo '==> Clean the working environment. ============================'
+exec >> log_Jenkins
+echo '==> Clean the working environment. ============================'
+if [ -d "/data/jenkins/workspace/${DATA_DIR}/$PRCHANGE_ID" ]
+then
+    echo 'Remove the old directory ' /data/jenkins/workspace/${DATA_DIR}/${PRCHANGE_ID}
+    rm -rf /data/jenkins/workspace/${DATA_DIR}/${PRCHANGE_ID}
+fi
+echo '   '

--- a/scripts/clean_environment.sh
+++ b/scripts/clean_environment.sh
@@ -17,12 +17,20 @@ exec >> log_Jenkins
 echo '==> Clean the working environment. ============================'
 
 pwd
-# Clean the validation package local repository
-if [ -d "./HGCTPGValidation" ] 
+# Remove the validation package local repository
+if [ -d "./HGCTPGValidation" ]
 then
     rm -rf HGCTPGValidation
 fi
 
+# Remove the test_dir that contains the ROOT files from the CMSSW test and ref simulations
+if [ -d "./test_dir" ]
+then
+    echo "Directory test_dir exists."
+    rm -rf test_dir
+fi
+
+# Remove the directory containing the images with histograms
 if [ -d "/data/jenkins/workspace/${DATA_DIR}/$PRCHANGE_ID" ]
 then
     echo 'Remove the old directory ' /data/jenkins/workspace/${DATA_DIR}/${PRCHANGE_ID}

--- a/scripts/clean_environment.sh
+++ b/scripts/clean_environment.sh
@@ -16,13 +16,6 @@ echo '==> Clean the working environment. ============================'
 exec >> log_Jenkins
 echo '==> Clean the working environment. ============================'
 
-pwd
-# Remove the validation package local repository
-if [ -d "./HGCTPGValidation" ]
-then
-    rm -rf HGCTPGValidation
-fi
-
 # Remove the test_dir that contains the ROOT files from the CMSSW test and ref simulations
 if [ -d "./test_dir" ]
 then

--- a/scripts/clean_environment.sh
+++ b/scripts/clean_environment.sh
@@ -15,6 +15,14 @@ set +x
 echo '==> Clean the working environment. ============================'
 exec >> log_Jenkins
 echo '==> Clean the working environment. ============================'
+
+pwd
+# Clean the validation package local repository
+if [ -d "./HGCTPGValidation" ] 
+then
+    rm -rf HGCTPGValidation
+fi
+
 if [ -d "/data/jenkins/workspace/${DATA_DIR}/$PRCHANGE_ID" ]
 then
     echo 'Remove the old directory ' /data/jenkins/workspace/${DATA_DIR}/${PRCHANGE_ID}

--- a/scripts/geom_check.sh
+++ b/scripts/geom_check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Usage: ./HGCTPGValidation/scripts/geom_check.sh ${TEST_RELEASE} ${LABEL_TEST}
+
+echo '===> Geometry checking.'
+
+# Check if there are 2 arguments supplied to the script
+if (( $# != 2 ))
+then
+  echo "Usage: ./HGCTPGValidation/scripts/geom_check.sh TEST_RELEASE LABEL_TEST"
+  exit 1
+fi
+
+TEST_RELEASE=$1
+LABEL_TEST=$2
+
+cd test_dir/${TEST_RELEASE}_HGCalTPGValidation_${LABEL_TEST}/src
+source /cvmfs/cms.cern.ch/cmsset_default.sh; 
+eval `scramv1 runtime -sh`;
+cmsRun L1Trigger/L1THGCal/test/testHGCalL1TGeometryV16_cfg.py
+

--- a/scripts/installCMSSW_global.sh
+++ b/scripts/installCMSSW_global.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This code is to use with Jenkins jobs triggering on Github Pull Request in the repository https://github.com/hgc-tpg
-# ./installCMSSW.sh $SCRAM_ARCH $REF_RELEASE $REMOTE $BASE_REMOTE $CHANGE_BRANCH $CHANGE_TARGET ${LABEL_TEST}
+# ./installCMSSW_global.sh $SCRAM_ARCH $REF_RELEASE $REMOTE $BASE_REMOTE $CHANGE_BRANCH $CHANGE_TARGET ${LABEL_TEST}
 
 # $1 SCRAM_ARCH
 # $2 release name
@@ -10,6 +10,14 @@
 # $5 branch name (corresponds to the branch containing the changes)
 # $6 reference branch name (this is the target or base branch to which the change could be merged, it is in https://github.com/hgc-tpg repository)
 # $7 label "ref" or "test"
+
+set +x
+echo '==> Build CMSSW Test ========================='
+echo '===> InstallCMSSW Test Step'
+exec >> log_Jenkins
+echo '==> Build CMSSW Test ========================='
+echo '===> InstallCMSSW Test Step'
+cd test_dir
 
 set -e
 
@@ -42,4 +50,5 @@ git checkout -b local_$branch_ref $baseremote/$branch_ref
 git cms-merge-topic $remote:$branch
 # Compile
 scram b -j8
+
 

--- a/scripts/produceData_multiconfiguration.py
+++ b/scripts/produceData_multiconfiguration.py
@@ -51,7 +51,7 @@ def run_cmsDriver(configdata, release):
     --filein {filein} \
     --no_output \
     {customise} \
-    --customise_commands {customiseCommand}"
+    --customise_commands {customiseCommand} & ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! {INTERVAL} {RSS_limit}"
     
     pprint.pprint(command)
     return command

--- a/scripts/quality_checks.sh
+++ b/scripts/quality_checks.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Usage: ./HGCTPGValidation/scripts/quality_checks.sh ${REF_RELEASE} ${LABEL_TEST}
+
+# Check if there are 2 arguments supplied to the script
+if (( $# != 2 ))
+then
+  echo "Usage: ./HGCTPGValidation/scripts/quality_checks.sh ${REF_RELEASE} ${LABEL_TEST}"
+  exit 1
+fi
+
+REF_RELEASE=$1
+LABEL_TEST=$2
+
+set +x
+echo '===> Quality checks'
+exec >> log_Jenkins
+echo '===> Quality checks'
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+cd test_dir/${REF_RELEASE}_HGCalTPGValidation_${LABEL_TEST}/src
+scram build code-checks
+scram build code-format
+GIT_STATUS=`git status --porcelain`
+if [ ! -z "$GIT_STATUS" ]; then
+    echo "Code-checks or code-format failed."
+    exit 1;
+fi
+echo '    '

--- a/scripts/write_toGitHub.sh
+++ b/scripts/write_toGitHub.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# This script has two purposes:
+# 1) Generate a temporary token
+# 2) Write into the PR thread in GitHub 
+
+# Usage: ./HGCTPGValidation/scripts/write_toGitHub.sh $url $MESSAGE
+
+echo '===> Write into the PR thread.'
+
+# Check if there are 2 arguments supplied to the script
+if (( $# != 2 ))
+then
+  echo "Usage: ./HGCTPGValidation/scripts/write_toGitHub.sh $url $MESSAGE"
+  exit 1
+fi
+
+url="$1"
+MESSAGE="$2"
+
+# Generate a token, the command "set +x" is mandatory
+set +x exec >> log_Jenkins; 
+module use /opt/exp_soft/vo.llr.in2p3.fr/modulefiles_el7/; 
+module purge; module load python/3.9.9; 
+# For the organization hgc-tpg
+python /data/jenkins/workspace/create_token_hgc-tpg.py > /tmp/github_token
+# For the organization test-org-hgctpg
+#python /data/jenkins/workspace/create_token.py > /tmp/github_token
+
+# Compose the url to be used for printing the message in the GitHub PR thread
+# In the string "url" replace "pull" with "issues" and add at the end "comments"
+url_comments1="${url/pull/issues}/comments"
+# In the string "url_comments1" replace "github.com" with "api.github.com/repos"
+url_comments2="${url_comments1/github.com/api.github.com/repos}"
+GITHUB_ACCESS_TOKEN=$(cat /tmp/github_token)
+if [[ -z "${GITHUB_ACCESS_TOKEN}" ]]; then
+    echo 'The github access token has not been generated.'
+else
+    echo "{\"body\": \"$MESSAGE\"}"
+    curl -X POST -H "Authorization: Bearer $GITHUB_ACCESS_TOKEN " \
+     -H "Accept: application/vnd.github+json" \
+     -d "{\"body\": \"$MESSAGE\"}"  \
+     "$url_comments2"
+fi
+rm -f /tmp/github_token
+


### PR DESCRIPTION
Testing a new Jenkins feature: reorganize initialize stage
- Move two parts of the stage 'Install automatic validation package HGCTPGValidation' to the script clean_environment.sh
- In the stage 'Clean the working environment' group all the cleaning procedures
- In the stage 'Install automatic validation package HGCTPGValidation' keep only the commands for installing the validation code 